### PR TITLE
Add neural framework related stuff

### DIFF
--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -57,7 +57,7 @@
 
 					add_attack_logs(user,M,"Implanted with [imp.name] using [name]")
 
-					if(imp.handle_implant(M))
+					if(imp.handle_implant(M, user.zone_sel.selecting))
 						imp.post_implant(M)
 
 						if(ishuman(M))

--- a/code/modules/client/preference_setup/loadout/loadout_cyberware.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_cyberware.dm
@@ -9,8 +9,8 @@
 	exploitable = 1
 
 /datum/gear/cyberware/neural
-	display_name = "implant, neural assistance web"
-	description = "A complex web implanted into the subject, medically in order to compensate for neurological disease."
+	display_name = "implant, neural framework"
+	description = "A complex web implanted into the subject, medically in order to add ability to control prostheses."
 	path = /obj/item/weapon/implant/neural
 	cost = 0
 

--- a/code/modules/research/prosfab_designs.dm
+++ b/code/modules/research/prosfab_designs.dm
@@ -55,6 +55,24 @@
 		H.add_language(LANGUAGE_EAL)
 		return H
 
+/// implanter and implant for prosthetics ///
+/datum/design/item/prosfab/implants
+	category = "Prosthetics"
+
+/datum/design/item/prosfab/implants/implanter
+	name = "Implanter"
+	id = "implanter"
+	build_path = /obj/item/weapon/implanter
+	time = 15
+	materials = list(DEFAULT_WALL_MATERIAL = 4000, "glass" = 4000)
+
+/datum/design/item/prosfab/implants/neural_implant
+	name = "Neural Framework Implant"
+	id = "neural_implant"
+	build_path = /obj/item/weapon/implant/neural
+	time = 20
+	materials = list(DEFAULT_WALL_MATERIAL = 7500, "copper" = 1250, "aluminium" = 1250)
+
 //////////////////// Prosthetics ////////////////////
 /datum/design/item/prosfab/pros/torso
 	time = 35

--- a/html/changelogs/vlad777.yml
+++ b/html/changelogs/vlad777.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: vlad777
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed infinite cigarettes."
+  - rscadd: "Added implanter and cyberware implant in robotics fabricator."
+  - rscadd: "Added ability to choose zone where implant will be implanted."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR adds:
1. Zone selecting to implanter, now place where implant will be depends on your zone selection.
2. Implanter and neural framework implant recipes to prosthesis fabricator
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It adds ability to fix amputee in round, without need to return to loadout screen and add 'neural framework implant' in it.
You just need to print implanter and neural framework implant and put implant in amputee head (don't forget about zone selection, neural implants dont work while in legs/arms/torso.

## Changelog
:cl:
add: Added implanter and neural framework implant to prosthesis fabricator.
add: Added implanter zone selecting.
/:cl:

close #9

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->