### PR TITLE
Fix water fountain

### DIFF
--- a/code/game/objects/structures/props/misc.dm
+++ b/code/game/objects/structures/props/misc.dm
@@ -45,3 +45,16 @@
 	reagents.trans_to_mob(user, issmall(user) ? 2.5 : 5, CHEM_INGEST)
 	qdel(reagents)
 	..()
+
+/obj/structure/prop/water_fountain/attackby(obj/item/W, mob/user)
+	if(!istype(W, /obj/item/weapon/reagent_containers))
+		return FALSE
+	
+	var/obj/item/weapon/reagent_containers/R = W
+	
+	to_chat(user, "<span class='notice'>You fill [W] with some water from fountain.</span>")
+	user.setClickCooldown(user.get_attack_speed(src))
+
+	var/datum/reagents/reagents = new /datum/reagents
+	reagents.add_reagent("water", 5)
+	reagents.trans_to_holder(R.reagents, 5)

--- a/code/game/objects/structures/props/misc.dm
+++ b/code/game/objects/structures/props/misc.dm
@@ -21,7 +21,7 @@
 	desc = "A water fountain for drinking, naturally."
 	icon = 'icons/obj/watercloset.dmi'
 	icon_state = "water_fountain"
-	interaction_message = "<span class = 'notice'>You sip some water from fontain.</span>"
+	interaction_message = "<span class='notice'>You sip some water from fountain.</span>"
 
 /obj/structure/prop/water_fountain/attack_hand(mob/living/user)
 	if(!istype(user, /mob/living/carbon/human))
@@ -29,7 +29,7 @@
 
 	var/mob/living/carbon/human/H = user
 	if(!H.check_has_mouth())
-		to_chat(user, "How do you want to drink water? You don't have a mouth!")
+		to_chat(user, "<span class='warning'>How do you want to drink water? You don't have a mouth!</span>")
 		return FALSE
 
 	var/obj/item/blocked = H.check_mouth_coverage()

--- a/code/game/objects/structures/props/misc.dm
+++ b/code/game/objects/structures/props/misc.dm
@@ -15,3 +15,33 @@
 	density = TRUE
 	anchored= TRUE
 	interaction_message = "An old fortten gift machine. The treasures it once held have been lost to time or found a new home inside a pawnshop."
+
+/obj/structure/prop/water_fountain
+	name = "water fountain"
+	desc = "A water fountain for drinking, naturally."
+	icon = 'icons/obj/watercloset.dmi'
+	icon_state = "water_fountain"
+	interaction_message = "<span class = 'notice'>You sip some water from fontain.</span>"
+
+/obj/structure/prop/water_fountain/attack_hand(mob/living/user)
+	if(!istype(user, /mob/living/carbon/human))
+		return FALSE
+
+	var/mob/living/carbon/human/H = user
+	if(!H.check_has_mouth())
+		to_chat(user, "How do you want to drink water? You don't have a mouth!")
+		return FALSE
+
+	var/obj/item/blocked = H.check_mouth_coverage()
+	if(blocked)
+		user << "<span class='warning'>\The [blocked] is in the way!</span>"
+		return FALSE
+
+	user.setClickCooldown(user.get_attack_speed(src))
+	playsound(user.loc, 'sound/items/drink.ogg', rand(10, 50), 1)
+
+	var/datum/reagents/reagents = new /datum/reagents
+	reagents.add_reagent("water", 5)
+	reagents.trans_to_mob(user, issmall(user) ? 2.5 : 5, CHEM_INGEST)
+	qdel(reagents)
+	..()

--- a/code/game/objects/structures/props/misc.dm
+++ b/code/game/objects/structures/props/misc.dm
@@ -58,3 +58,4 @@
 	var/datum/reagents/reagents = new /datum/reagents
 	reagents.add_reagent("water", 5)
 	reagents.trans_to_holder(R.reagents, 5)
+	qdel(reagents)

--- a/code/game/objects/structures/props/statues.dm
+++ b/code/game/objects/structures/props/statues.dm
@@ -9,13 +9,6 @@
 	icon = 'icons/obj/props/misc.dmi'
 	icon_state = "infoterm"
 
-/obj/structure/prop/water_fountain //Move this to misc.dm in the next PR and remove this comment!
-	name = "water fountain"
-	desc = "A water fountain for drinking, naturally."
-	icon = 'icons/obj/watercloset.dmi'
-	icon_state = "water_fountain"
-	interaction_message = "<span class = 'notice'>Out of order. What a ripoff.</span>"
-
 /obj/structure/prop/statue/phoron
 	name = "phoronic cascade"
 	desc = "A sculpture made of pure phoron. It is covered in a lacquer that prevents erosion and renders it fireproof. It's safe. Probably."

--- a/html/changelogs/vlad777.yml
+++ b/html/changelogs/vlad777.yml
@@ -33,4 +33,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - rscadd: "Added ability to drink water from water fountain."
+  - rscadd: "Added ability to drink water from water fountain and fill reagent containers from it."

--- a/html/changelogs/vlad777.yml
+++ b/html/changelogs/vlad777.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: vlad777
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added ability to drink water from water fountain."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR adds ability to drink water (5u per click digested) from water fountains and fill reagent containers (beakers, bottles, cups etc) from it (5u per click too).

## Changelog
:cl:
add: Added ability to drink water from water fountains.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->