### PR TITLE
Fix non-vetra voting rights

### DIFF
--- a/code/modules/government/law/_law_vars.dm
+++ b/code/modules/government/law/_law_vars.dm
@@ -19,7 +19,7 @@
 			if(B.robotic > 1)
 				return "Has a Synthetic Brain"
 
-	if(!SSpersistent_options.get_persistent_option_value("voting_noncitizen"))
+	if(!SSpersistent_options.get_persistent_option_value("voting_nonnational"))
 		if(H.home_system != using_map.starsys_name)
 			return "Is from [H.home_system] and not from [using_map.starsys_name]"
 

--- a/html/changelogs/vlad777.yml
+++ b/html/changelogs/vlad777.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: vlad777
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed voting rights for non-Vetra citizens. Futher testing required."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixed persistent option name on ballotbox, so now if non-vetra is allowed to vote they will be able to do that.
Not tested bugfix local, so futher testing required before merging in master I think? Game compiles and runs, so anyway you can merge it if you sure.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed non-vetra right to vote
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->