### PR TITLE
Allows players to set custom citizenship/home systems

### DIFF
--- a/code/game/objects/items/weapons/id cards/passports.dm
+++ b/code/game/objects/items/weapons/id cards/passports.dm
@@ -33,6 +33,9 @@
 	if(pass.citizenship == "Andromeda") pass.icon_state = "androgov_passport"  //Matches icon to location
 	else if(pass.citizenship == "Vetra") pass.icon_state = "polgov_passport"
 	else if(pass.citizenship == "Sol") pass.icon_state = "solgov_passport"
+	else if(pass.citizenship == "Other")
+		pass.icon_state = "passport"
+		pass.desc = "This is an electronic passport that allows you to travel between colonies."
 	else if(pass.citizenship == "Cobrastan") pass.icon_state = "cobrastan_passport" //a cheeky little easter egg for fans of Papers, Please
 	else icon_state = "passport"
 
@@ -47,8 +50,8 @@
 		user.update_passport(src)
 		edits_left = 0
 	else
-		user.visible_message("\The [user] flashes their passport. It shows that [owner] was born in [citizenship].",\
-			"You flash your passport. It shows that [owner] was born in [citizenship].")
+		user.visible_message("\The [user] flashes their passport. It shows that [owner] is from [citizenship].",\
+			"You flash your passport. It shows that [owner] is from [citizenship].")
 
 		src.add_fingerprint(user)
 		return

--- a/code/game/objects/items/weapons/id cards/passports.dm
+++ b/code/game/objects/items/weapons/id cards/passports.dm
@@ -35,7 +35,6 @@
 	else if(pass.citizenship == "Sol") pass.icon_state = "solgov_passport"
 	else if(pass.citizenship == "Other")
 		pass.icon_state = "passport"
-		pass.desc = "This is an electronic passport that allows you to travel between colonies."
 	else if(pass.citizenship == "Cobrastan") pass.icon_state = "cobrastan_passport" //a cheeky little easter egg for fans of Papers, Please
 	else icon_state = "passport"
 

--- a/code/modules/client/preference_setup/general/03_background.dm
+++ b/code/modules/client/preference_setup/general/03_background.dm
@@ -51,8 +51,6 @@
 /datum/category_item/player_setup_item/general/background/sanitize_character()
 	if(!pref.home_system) pref.home_system = "Vetra"
 	if(!pref.citizenship) pref.citizenship = "Blue Colony"
-//	pref.home_system = sanitize_inlist(pref.home_system, home_system_choices, initial(pref.home_system))
-//	pref.citizenship = sanitize_inlist(pref.citizenship, citizenship_choices, initial(pref.citizenship))
 //	if(!pref.faction)     pref.faction =     "None"
 	if(!pref.religion)    pref.religion =    "None"
 	if(!pref.crime_record) pref.crime_record = list()

--- a/code/modules/client/preference_setup/general/03_background.dm
+++ b/code/modules/client/preference_setup/general/03_background.dm
@@ -51,8 +51,8 @@
 /datum/category_item/player_setup_item/general/background/sanitize_character()
 	if(!pref.home_system) pref.home_system = "Vetra"
 	if(!pref.citizenship) pref.citizenship = "Blue Colony"
-	pref.home_system = sanitize_inlist(pref.home_system, home_system_choices, initial(pref.home_system))
-	pref.citizenship = sanitize_inlist(pref.citizenship, citizenship_choices, initial(pref.citizenship))
+//	pref.home_system = sanitize_inlist(pref.home_system, home_system_choices, initial(pref.home_system))
+//	pref.citizenship = sanitize_inlist(pref.citizenship, citizenship_choices, initial(pref.citizenship))
 //	if(!pref.faction)     pref.faction =     "None"
 	if(!pref.religion)    pref.religion =    "None"
 	if(!pref.crime_record) pref.crime_record = list()
@@ -154,10 +154,10 @@
 		var/choice = input(user, "Please choose a home system.", "Character Preference", pref.home_system) as null|anything in home_system_choices
 		if(!choice || !CanUseTopic(user))
 			return TOPIC_NOACTION
-		if(choice == "Other")
+		else if(choice == "Other")
 			var/raw_choice = sanitize(input(user, "Please enter a home system.", "Character Preference")  as text|null, MAX_NAME_LEN)
-			if(raw_choice && CanUseTopic(user))
-				pref.home_system = raw_choice
+			if(raw_choice)
+				pref.home_system = sanitize(raw_choice)
 		else
 			pref.home_system = choice
 		return TOPIC_REFRESH
@@ -166,7 +166,12 @@
 		var/choice = input(user, "Please choose your current citizenship.", "Character Preference", pref.citizenship) as null|anything in citizenship_choices
 		if(!choice || !CanUseTopic(user))
 			return TOPIC_NOACTION
-		pref.citizenship = choice
+		else if(choice == "Other")
+			var/raw_choice = sanitize(input(user, "Please enter a home system.", "Character Preference")  as text|null, MAX_NAME_LEN)
+			if(raw_choice)
+				pref.citizenship = sanitize(raw_choice)
+		else
+			pref.citizenship = choice
 		return TOPIC_REFRESH
 /*
 	else if(href_list["faction"])

--- a/code/modules/client/preferences_factions.dm
+++ b/code/modules/client/preferences_factions.dm
@@ -20,13 +20,15 @@ var/global/list/citizenship_choices = list(
 	"Ocral Spax B",
 	"Glace Gria",
 	"Glace Grace",
-	"Castor"
+	"Castor",
+	"Other"
 	)
 
 var/global/list/home_system_choices = list(
 	"Vetra",
 	"Sol",
-	"Andromeda"
+	"Andromeda",
+	"Other"
 	)
 
 var/global/list/faction_choices = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This adds an "Other" option to character setup under citizenship and home system, allowing the player to set a custom name for their character's home. Also slightly tweaks the flavour text of passports.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
This expands the range of background options available to players, rather than restricting them to three specific systems.

## Changelog
:cl:
tweak: Players can now set custom home systems and citizenship locations
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->