### PR TITLE
Reworks decloner's tech requirements to be obtainable and replaces the Green Goo bounty 

### DIFF
--- a/code/modules/bounty/presets/gun.dm
+++ b/code/modules/bounty/presets/gun.dm
@@ -61,7 +61,7 @@
 	description = "Excuse me - it appears that my latest Zombie-Stomping rampage has left quite an abundance of viscera around.\
 	If I may, I'd like to request some heavy-duty cleaning equipment. With kind regards, MC Fist."
 
-	items_wanted = list(/obj/item/weapon/reagent_containers/spray/chemsprayer = 1)
+	items_wanted = list(/obj/item/weapon/reagent_containers/spray/chemsprayer = 2)
 
 	department_reward = 600
 	individual_reward = 150

--- a/code/modules/bounty/presets/gun.dm
+++ b/code/modules/bounty/presets/gun.dm
@@ -56,11 +56,12 @@
 	days_until_expiry = 2
 
 /datum/bounty/gun/bioweapon
-	name = "Green Goo"
+	name = "Cleaning up the Streets"
 	author = "Master Commander Fist McLaserbiceps Odinkiller Zombiestomper Doomslayer MCLXVII"
-	description = "\[This message has been redacted due to violating the terms of service.\]"
+	description = "Excuse me - it appears that my latest Zombie-Stomping rampage has left quite an abundance of viscera around.\
+	If I may, I'd like to request some heavy-duty cleaning equipment. With kind regards, MC Fist."
 
-	items_wanted = list(/obj/item/weapon/gun/energy/decloner = 1)
+	items_wanted = list(/obj/item/weapon/reagent_containers/spray/chemsprayer = 1)
 
 	department_reward = 600
 	individual_reward = 150

--- a/code/modules/bounty/presets/gun.dm
+++ b/code/modules/bounty/presets/gun.dm
@@ -7,7 +7,7 @@
 	author = "Howard Hows"
 	description = "So my guards are not looking \"future soldier\" enough. I change out their outfits almost once a year \
 	with new doodads but something is missing. Ah! Their gun does not have an adjective in the name. Simply out of date. \
-	Please make sure to send 4 Prototype SMGs so normal troop’s equipment does not catch up to ours."
+	Please make sure to send 4 Prototype SMGs so normal troopâ€™s equipment does not catch up to ours."
 
 	items_wanted = list(/obj/item/weapon/gun/projectile/automatic = 4)
 
@@ -56,7 +56,7 @@
 	days_until_expiry = 2
 
 /datum/bounty/gun/bioweapon
-	name = "Cleaning up the Streets"
+	name = "Cleaning Up the Streets"
 	author = "Master Commander Fist McLaserbiceps Odinkiller Zombiestomper Doomslayer MCLXVII"
 	description = "Excuse me - it appears that my latest Zombie-Stomping rampage has left quite an abundance of viscera around.\
 	If I may, I'd like to request some heavy-duty cleaning equipment. With kind regards, MC Fist."
@@ -82,8 +82,8 @@
 	name = "Don't Taze Me Bro!"
 	author = "Hammerdown"
 
-	description = "We’re in need of equipment for our next run. It's gonna be a milk run this time, I can feel it. This one’s gotta stay lowkey so \
-	we’re going with non-lethal weapons - Twitchers, specifically. Get us 3 stun revolvers to outfit the crew and we’ll send some credits your way."
+	description = "Weâ€™re in need of equipment for our next run. It's gonna be a milk run this time, I can feel it. This oneâ€™s gotta stay lowkey so \
+	weâ€™re going with non-lethal weapons - Twitchers, specifically. Get us 3 stun revolvers to outfit the crew and weâ€™ll send some credits your way."
 
 	items_wanted = list(/obj/item/weapon/gun/energy/stunrevolver = 3)
 

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -657,7 +657,7 @@ other types of metals and chemistry for reagents).
 
 /datum/design/item/weapon/decloner
 	id = "decloner"
-	req_tech = list(TECH_COMBAT = 8, TECH_MATERIAL = 7, TECH_BIO = 5, TECH_POWER = 6)
+	req_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 6, TECH_BIO = 5, TECH_ILLEGAL = 3)
 	materials = list("gold" = 5000,"uranium" = 10000, "plastic" = 1000)
 	chemicals = list("mutagen" = 40)
 	build_path = /obj/item/weapon/gun/energy/decloner

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -655,15 +655,6 @@ other types of metals and chemistry for reagents).
 	sort_string = "TAAAD"
 	price = 6000
 
-/datum/design/item/weapon/decloner
-	id = "decloner"
-	req_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 6, TECH_BIO = 5, TECH_ILLEGAL = 3)
-	materials = list("gold" = 5000,"uranium" = 10000, "plastic" = 1000)
-	chemicals = list("mutagen" = 40)
-	build_path = /obj/item/weapon/gun/energy/decloner
-	sort_string = "TAAAE"
-	price = 10000
-
 /datum/design/item/weapon/smg
 	id = "smg"
 	req_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3)

--- a/html/changelogs/faaaay-PR-80.yml
+++ b/html/changelogs/faaaay-PR-80.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: faaaay
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "lowers the tech requirements of the decloner and replaces its TECH_POWER with TECH_ILLEGAL"
+  - rscadd: "adds Cleaning Up the Streets bounty"
+  - rscdel: "removes the Green Goo bounty"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
(closes #70)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Lowers TECH_COMBAT to 5, replaces TECH_POWER with TECH_ILLEGAL 3 and reduces TECH_MATERIAL to 6
As it stands, the decloner is not obtainable without getting your hands on some very powerful admin-spawned weapons. While it _is_ a solid weapon (due to dealing a damage type that can't easily be fixed on the spot), it's not quite powerful enough to justify the steep tech requirements. This PR lowers some of the levels (and replaces the POWER requirement with ILLEGAL) to allow it to be obtained through a bit of luck.

With that said, it does kind of suck to get sent a bounty that relies on _happening_ to obtain a broken emag and specific drone parts, and so the Green Goo bounty is also removed by this PR. But! It's replaced with another, asking for 2 chemsprayers.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
At the moment, the decloner is more-or-less impossible to get without adminbus. This makes it a bit more plausible to obtain.
In addition, having bounties that rely solely on RNG (whether you can get the right tech) isn't very fun.

## Changelog
:cl:
add: added the Cleaning Up the Streets bounty
del: removed the Green Goo bounty
balance: lowered the decloner's tech requirements and replaced the TECH_POWER req with TECH_ILLEGAL
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->