### PR TITLE
Move PARAMEDIC down to MEDSCI

### DIFF
--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -12,7 +12,6 @@ var/const/ATMOSTECH				=(1<<7)
 var/const/AI					=(1<<8)
 var/const/CYBORG				=(1<<9)
 
-var/const/PARAMEDIC				=(1<<10)
 var/const/POL_CADET				=(1<<11)
 
 var/const/MEDSCI				=(1<<1)
@@ -27,9 +26,10 @@ var/const/VIROLOGIST			=(1<<6)
 var/const/PSYCHIATRIST			=(1<<7)
 var/const/ROBOTICIST			=(1<<8)
 var/const/XENOBIOLOGIST			=(1<<9)
-var/const/MEDICALINTERN			=(1<<10)
-var/const/SCIENCEINTERN			=(1<<11)
-var/const/SCIGUARD				=(1<<12)
+var/const/PARAMEDIC				=(1<<10)
+var/const/MEDICALINTERN			=(1<<11)
+var/const/SCIENCEINTERN			=(1<<12)
+var/const/SCIGUARD				=(1<<13)
 
 var/const/CIVILIAN				=(1<<2)
 

--- a/html/changelogs/faaaay-PR-81.yml
+++ b/html/changelogs/faaaay-PR-81.yml
@@ -1,0 +1,34 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: faaaay
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Paramedic and Medical Intern priorities are now seperate"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Closes #76 
Moves Paramedics down to the Medsci section in jobs.dm, allowing them to have their priority set seperately from Medical Interns. No, I don't know why they weren't there in the first place.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Just fixes a bug with the priority menu. Bugs bad.

## Changelog
:cl:
fix: Paramedic and Medical Intern priorities are now seperate
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->