### PR TITLE
Allows security borgs to exist again

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules/station.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station.dm
@@ -6,6 +6,7 @@ var/global/list/robot_modules = list(
 	"Miner" 		= /obj/item/weapon/robot_module/robot/miner,
 	"Crisis" 		= /obj/item/weapon/robot_module/robot/medical/crisis,
 	"Surgeon" 		= /obj/item/weapon/robot_module/robot/medical/surgeon,
+	"Security"      = /obj/item/weapon/robot_module/robot/security/general,
 	"Engineering"	= /obj/item/weapon/robot_module/robot/engineering/general,
 //	"Construction"	= /obj/item/weapon/robot_module/robot/engineering/construction,
 	"Janitor" 		= /obj/item/weapon/robot_module/robot/janitor

--- a/html/changelogs/faaaay-PR-79.yml
+++ b/html/changelogs/faaaay-PR-79.yml
@@ -31,4 +31,4 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - bugfix: "Paramedic and Medical Intern priorities are now seperate"
+  - bugfix: "cyborgs are once again able to select the Security module"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
The security cyborg module was, for unknown reasons, not able to be selected - trying would lead to a bug. This just re-adds them to the list and lets them be selected once again.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Bug bad, bug fix good. This bug could end up causing a borg to be unable to pick a module.

## Changelog
:cl:
fix: allows the Security borg module to be chosen again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->