### PR TITLE
Fixes bone-setting surgery

### DIFF
--- a/changelogs/faaaay-PR-91.yml
+++ b/changelogs/faaaay-PR-91.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: faaay
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "bone-fixing surgery is now done by applying a bone setter and then bone gel"
+  - tweak: "bones cannot be fixed if their limb has taken enough damage to break"

--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -2,47 +2,6 @@
 //////////////////////////////////////////////////////////////////
 //						BONE SURGERY							//
 //////////////////////////////////////////////////////////////////
-
-///////////////////////////////////////////////////////////////
-// Bone Glue Surgery
-///////////////////////////////////////////////////////////////
-/*
-/datum/surgery_step/glue_bone
-	allowed_tools = list(
-	/obj/item/weapon/surgical/bonegel = 100,	\
-	/obj/item/weapon/screwdriver = 75
-	)
-	can_infect = 1
-	blood_level = 1
-
-	min_duration = 50
-	max_duration = 60
-
-/datum/surgery_step/glue_bone/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	if (!hasorgans(target))
-		return 0
-	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	return affected && (affected.robotic < ORGAN_ROBOT) && affected.open >= 2 && affected.stage == 0
-
-/datum/surgery_step/glue_bone/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	if (affected.stage == 0)
-		user.visible_message("<font color='blue'>[user] starts applying medication to the damaged bones in [target]'s [affected.name] with \the [tool].</font>" , \
-		"<font color='blue'>You start applying medication to the damaged bones in [target]'s [affected.name] with \the [tool].</font>")
-	target.custom_pain("Something in your [affected.name] is causing you a lot of pain!", 50)
-	..()
-
-/datum/surgery_step/glue_bone/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message("<font color='blue'>[user] applies some [tool] to [target]'s bone in [affected.name]</font>", \
-		"<font color='blue'>You apply some [tool] to [target]'s bone in [affected.name] with \the [tool].</font>")
-	affected.stage = 1
-
-/datum/surgery_step/glue_bone/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message("<font color='red'>[user]'s hand slips, smearing [tool] in the incision in [target]'s [affected.name]!</font>" , \
-	"<font color='red'>Your hand slips, smearing [tool] in the incision in [target]'s [affected.name]!</font>")
-*/
 ///////////////////////////////////////////////////////////////
 // Bone Setting Surgery
 ///////////////////////////////////////////////////////////////

--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -6,7 +6,7 @@
 ///////////////////////////////////////////////////////////////
 // Bone Glue Surgery
 ///////////////////////////////////////////////////////////////
-
+/*
 /datum/surgery_step/glue_bone
 	allowed_tools = list(
 	/obj/item/weapon/surgical/bonegel = 100,	\
@@ -42,7 +42,7 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<font color='red'>[user]'s hand slips, smearing [tool] in the incision in [target]'s [affected.name]!</font>" , \
 	"<font color='red'>Your hand slips, smearing [tool] in the incision in [target]'s [affected.name]!</font>")
-
+*/
 ///////////////////////////////////////////////////////////////
 // Bone Setting Surgery
 ///////////////////////////////////////////////////////////////
@@ -60,7 +60,7 @@
 	if (!hasorgans(target))
 		return 0
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	return affected && affected.organ_tag != BP_HEAD && !(affected.robotic >= ORGAN_ROBOT) && affected.open >= 2 && affected.stage == 1
+	return affected && affected.organ_tag != BP_HEAD && !(affected.robotic >= ORGAN_ROBOT) && affected.open >= 2 && affected.stage == 0
 
 /datum/surgery_step/set_bone/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -74,7 +74,7 @@
 	if (affected.status & ORGAN_BROKEN)
 		user.visible_message("<font color='blue'>[user] sets the bone in [target]'s [affected.name] in place with \the [tool].</font>", \
 			"<font color='blue'>You set the bone in [target]'s [affected.name] in place with \the [tool].</font>")
-		affected.stage = 2
+		affected.stage = 1
 	else
 		user.visible_message("[user] sets the bone in [target]'s [affected.name]<font color='red'> in the WRONG place with \the [tool].</font>", \
 			"You set the bone in [target]'s [affected.name]<font color='red'> in the WRONG place with \the [tool].</font>")
@@ -143,7 +143,7 @@
 	if (!hasorgans(target))
 		return 0
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	return affected && affected.open >= 2 && !(affected.robotic >= ORGAN_ROBOT) && affected.stage == 2
+	return affected && affected.open >= 2 && !(affected.robotic >= ORGAN_ROBOT) && affected.stage == 1
 
 /datum/surgery_step/finish_bone/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -153,10 +153,15 @@
 
 /datum/surgery_step/finish_bone/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message("<font color='blue'>[user] has mended the damaged bones in [target]'s [affected.name] with \the [tool].</font>"  , \
+	if (affected.brute_dam < affected.min_broken_damage)
+		user.visible_message("<font color='blue'>[user] has mended the damaged bones in [target]'s [affected.name] with \the [tool].</font>"  , \
 		"<font color='blue'>You have mended the damaged bones in [target]'s [affected.name] with \the [tool].</font>" )
-	affected.status &= ~ORGAN_BROKEN
-	affected.stage = 0
+		affected.status &= ~ORGAN_BROKEN
+		affected.stage = 0
+	else
+		user.visible_message("<font color='red'>[user] tries to finish mending the damaged bones in [target]'s [affected.name] with \the [tool], but the [affected.name] is too damaged!</font>", \
+		"<font color='red'>You try to finish mending the damaged bones in [target]'s [affected.name] with \the [tool], but the [affected.name] is too damaged!</font>")
+
 
 /datum/surgery_step/finish_bone/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Currently, the bone-fixing surgery does not function. It needs you to go incision > gel > setter > gel, but you can't apply the gel for the second time - and if you COULD, the limb would immediately rebreak.
This makes two changes:
- The procedure is now incision > setter > gel. 
- The surgeon will be prevented from applying the gel if the limb is above the minimum damage to break (and would instantly break upon being fixed).

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Aside from allowing the surgery to be performed, this is good because - realistically speaking - if a limb is _so damaged_ that it'd break, it doesn't make much sense that you could fix the bone in the first place.

## Changelog
:cl:
tweak: bone-fixing surgery is now done by applying a bone setter and then bone gel
tweak: bones cannot be fixed if their limb has taken enough damage to break
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->