### PR TITLE
Fall damage is no longer absolutely absurd

### DIFF
--- a/changelogs/faaaay-fall-balancing.yml
+++ b/changelogs/faaaay-fall-balancing.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: faaay
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "falling from the first floor no longer makes you explode"

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -384,7 +384,7 @@
 		A.fall_impact(hit_atom, damage_min, damage_max, silent = TRUE)
 
 // Take damage from falling and hitting the ground
-/mob/living/fall_impact(var/atom/hit_atom, var/damage_min = 60, var/damage_max = 100, var/silent = FALSE, var/planetary = FALSE)
+/mob/living/fall_impact(var/atom/hit_atom, var/damage_min_short = 5, var/damage_max_short = 20, var/damage_min_planetary = 60, var/damage_max_planetary = 100, var/silent = FALSE, var/planetary = FALSE)
 	var/turf/landing = get_turf(hit_atom)
 	if(planetary && src.CanParachute())
 		if(!silent)
@@ -406,19 +406,22 @@
 					"You hear something slam into \the [landing].")
 				var/turf/T = get_turf(landing)
 				explosion(T, 0, 1, 2)
+				playsound(loc, "punch", 25, 1, -1)
+				for(var/i = 1 to 10) // Falling from orbit should absolutely fuck you up.
+					adjustBruteLoss(rand(damage_min_planetary, damage_max_planetary))
+				Weaken(4)
+				updatehealth()
 			else
 				visible_message("<span class='warning'>\The [src] falls from above and slams into \the [landing]!</span>", \
 					"<span class='danger'>You fall off and hit \the [landing]!</span>", \
 					"You hear something slam into \the [landing].")
-			playsound(loc, "punch", 25, 1, -1)
+				playsound(loc, "punch", 25, 1, -1)
+				for(var/i = 1 to 5) // Falling from the first floor really shouldn't be as bad as dropping from orbit. 5 * 5-20 averages out at 62.5, which is enough to require medical attention but not ENOUGH TO MAKE YOU EXPLODE
+					adjustBruteLoss(rand(damage_min_short, damage_max_short))
+				Weaken(4)
+				updatehealth()
+			return
 
-		// Because wounds heal rather quickly, 10 (the default for this proc) should be enough to discourage jumping off but not be enough to ruin you, at least for the first time.
-		// Hits 10 times, because apparently targeting individual limbs lets certain species survive the fall from atmosphere
-		for(var/i = 1 to 10)
-			adjustBruteLoss(rand(damage_min, damage_max))
-		Weaken(4)
-		updatehealth()
-		return
 
 //Using /atom/movable instead of /obj/item because I'm not sure what all humans can pick up or wear
 /atom/movable


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
As it stands, falling from the first floor does a **minimum** of 600 damage. That's four times your max health.
This PR tweaks the relevant proc to determine damage based on whether it's a planetary fall or not. If it's not, the damage is 5 iterations of 5-20. It still hurts, and may prevent you from walking, but the odds you'll die from it are slim.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Why in the world does a 10-foot fall instantly kill and potentially destroy limbs? 600-1000 damage is way over what it needs to be. This puts it in the realm of semi-realistic, but fair.

## Changelog
:cl:
tweak: non-orbit falls now deal 25-100 damage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->